### PR TITLE
Make prettyplotlib Python 3 compatible

### DIFF
--- a/prettyplotlib/__init__.py
+++ b/prettyplotlib/__init__.py
@@ -201,7 +201,7 @@ def hist(ax, x, **kwargs):
     """
     # Reassign the default colors to Set2 by Colorbrewer
     color_cycle = ax._get_lines.color_cycle
-    color = kwargs.pop('color', color_cycle.next())
+    color = kwargs.pop('color', next(color_cycle))
     facecolor = kwargs.pop('facecolor', color)
 
     # If no grid specified, don't draw one.
@@ -235,7 +235,7 @@ def plot(ax, x, y, **kwargs):
     else:
         # if no color is specified, cycle over the ones in this axis
         color_cycle = ax._get_lines.color_cycle
-        color = color_cycle.next()
+        color = next(color_cycle)
     if 'linewidth' not in kwargs:
         kwargs['linewidth'] = 0.75
 
@@ -258,7 +258,7 @@ def scatter(ax, x, y, **kwargs):
     if 'color' not in kwargs:
         # Assume that color means the edge color. You can assign the
         color_cycle = ax._get_lines.color_cycle
-        kwargs['color'] = color_cycle.next()
+        kwargs['color'] = next(color_cycle)
     if 'alpha' not in kwargs:
         kwargs['alpha'] = 0.5
     if 'linewidth' not in kwargs:

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,17 @@ setup(
     author='Olga B. Botvinnik',
     author_email='olga.botvinnik@gmail.com',
     packages=find_packages(),
-    license='LICENSE.txt',
+    license='MIT License',
     url='http://olgabot.github.io/prettyplotlib',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Scientific/Engineering'
+    ],
     description='Painlessly create beautiful default `matplotlib` plots.',
     long_description=open('README.txt').read(),
     install_requires=['matplotlib >= 1.2.1',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,11 @@
 from setuptools import setup
 from setuptools import find_packages
+import sys
+
+if sys.version_info[0] == 3:
+    LONG_DESCRIPTION = open('README.txt', encoding='utf-8').read()
+else:
+    LONG_DESCRIPTION = open('README.txt').read()
 
 setup(
     name='prettyplotlib',
@@ -16,10 +22,11 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.3',
         'Topic :: Scientific/Engineering'
     ],
     description='Painlessly create beautiful default `matplotlib` plots.',
-    long_description=open('README.txt').read(),
+    long_description=LONG_DESCRIPTION,
     install_requires=['matplotlib >= 1.2.1',
               'brewer2mpl >= 1.3.1']
 )

--- a/tests/test_bar.py
+++ b/tests/test_bar.py
@@ -6,6 +6,13 @@ from prettyplotlib import plt
 import numpy as np
 import os
 import string
+import six
+
+if six.PY3:
+    UPPERCASE_CHARS = string.ascii_uppercase
+else:
+    UPPERCASE_CHARS = string.uppercase
+
 
 @image_comparison(baseline_images=['bar'], extensions=['png'])
 def test_bar():
@@ -48,7 +55,7 @@ def test_bar_xticklabels():
     np.random.seed(14)
     n = 10
     ppl.bar(ax, np.arange(n), np.abs(np.random.randn(n)),
-            xticklabels=string.uppercase[:n])
+            xticklabels=UPPERCASE_CHARS[:n])
     # fig.savefig('%s/baseline_images/test_bar/bar_xticklabels.png' %
     #             os.path.dirname(__file__))
 

--- a/tests/test_pcolormesh.py
+++ b/tests/test_pcolormesh.py
@@ -9,6 +9,16 @@ import string
 from prettyplotlib import brewer2mpl
 from matplotlib.colors import LogNorm
 
+import six
+
+if six.PY3:
+    LOWERCASE_CHARS = string.ascii_lowercase
+    UPPERCASE_CHARS = string.ascii_uppercase
+else:
+    LOWERCASE_CHARS = LOWERCASE_CHARS
+    UPPERCASE_CHARS = UPPERCASE_CHARS
+
+
 @image_comparison(baseline_images=['pcolormesh'], extensions=['png'])
 def test_pcolormesh():
     fig, ax = plt.subplots(1)
@@ -27,8 +37,8 @@ def test_pcolormesh_labels():
     np.random.seed(10)
 
     ppl.pcolormesh(fig, ax, np.random.randn(10, 10),
-                   xticklabels=string.uppercase[:10],
-                   yticklabels=string.lowercase[-10:])
+                   xticklabels=UPPERCASE_CHARS[:10],
+                   yticklabels=LOWERCASE_CHARS[-10:])
     # fig.savefig('%s/baseline_images/test_pcolormesh/pcolormesh_labels.png' %
     #             os.path.dirname(__file__))
 
@@ -40,11 +50,11 @@ def test_pcolormesh_positive():
     np.random.seed(10)
 
     ppl.pcolormesh(fig, ax, np.random.uniform(size=(10, 10)),
-                   xticklabels=string.uppercase[:10],
-                   yticklabels=string.lowercase[-10:])
+                   xticklabels=UPPERCASE_CHARS[:10],
+                   yticklabels=LOWERCASE_CHARS[-10:])
     # fig.savefig('%s/baseline_images/test_pcolormesh/pcolormesh_positive.png' %
     #             os.path.dirname(__file__))
-    
+
 @image_comparison(baseline_images=['pcolormesh_negative'], extensions=['png'])
 def test_pcolormesh_negative():
     fig, ax = plt.subplots(1)
@@ -52,8 +62,8 @@ def test_pcolormesh_negative():
     np.random.seed(10)
 
     ppl.pcolormesh(fig, ax, -np.random.uniform(size=(10, 10)),
-                   xticklabels=string.uppercase[:10],
-                   yticklabels=string.lowercase[-10:])
+                   xticklabels=UPPERCASE_CHARS[:10],
+                   yticklabels=LOWERCASE_CHARS[-10:])
     # fig.savefig('%s/baseline_images/test_pcolormesh/pcolormesh_negative.png' %
     #             os.path.dirname(__file__))
 
@@ -81,8 +91,8 @@ def test_pcolormesh_positive_other_cmap():
     np.random.seed(10)
 
     ppl.pcolormesh(fig, ax, np.random.uniform(size=(10, 10)),
-                   xticklabels=string.uppercase[:10],
-                   yticklabels=string.lowercase[-10:],
+                   xticklabels=UPPERCASE_CHARS[:10],
+                   yticklabels=LOWERCASE_CHARS[-10:],
                    cmap=red_purple)
     # fig.savefig(
     #     '%s/baseline_images/test_pcolormesh/pcolormesh_positive_other_cmap.png' %


### PR DESCRIPTION
These patches add Python 3 compatibility to prettyplotlib. They may not be completely sufficient to guarantee full compatibility and there may be some lurking issues, however, the test scripts are passing on Python 3.3.2 on OS X 10.8.5 (as well as Python 2.7.5, still).

The number of lines of code that had to change to make the codebase run under both Python 2.7 and 3.3 was actually fairly small. In the future, for compatibility, authors should try to use forward-compatible language features (e.g., the `next()` function) in place of older idioms.

This pull request includes a branch created to increase the richness of the package description through PyPI trove classifiers. These will be displayed the next time a new version package is uploaded to PyPI, along with the Python 3 compatibility stamp.
