### PR TITLE
Fix a few typos in docstrings and comments.

### DIFF
--- a/prettyplotlib/_legend.py
+++ b/prettyplotlib/_legend.py
@@ -9,7 +9,7 @@ def legend(*args, **kwargs):
 
     @param args:
     @type args:
-    @param kwargs: Any keyword arugments to matplotlib's plt.legend()
+    @param kwargs: Any keyword arguments to matplotlib's plt.legend()
     Optional 'facecolor' keyword to change the facecolor of the legend
     @type kwargs:
     @return:
@@ -29,7 +29,7 @@ def legend(*args, **kwargs):
         rect.set_facecolor(facecolor)
         rect.set_linewidth(0.0)
 
-        # change the label colors in the legend to almost black
+        # Change the label colors in the legend to almost black
         # Change the legend label colors to almost black, too
         texts = legend.texts
         for t in texts:

--- a/prettyplotlib/_pcolormesh.py
+++ b/prettyplotlib/_pcolormesh.py
@@ -17,8 +17,8 @@ def pcolormesh(*args, **kwargs):
      of the heatmap block
      - xticklabels_rotation, which can be either 'horizontal' or 'vertical'
      depending on how you want the xticklabels rotated. The default is
-     'horiztonal' but if you have xticklabels that are longer, you may want
-     to do 'vertical' so they don't overlap
+     'horizontal', but if you have xticklabels that are longer, you may want
+     to do 'vertical' so they don't overlap.
      - yticklabels_rotation, which can also be either 'horizontal' or
      'vertical'. The default is 'horizontal' and in most cases,
      that's what you'll want to stick with. But the option is there if you


### PR DESCRIPTION
Hi Olga,
I'm so glad I stumbled across this library! It captures a number of things I used to do manually, too. This is the first time I'm using github and pull requests for collaboration, so I thought I'd start with a simple, non-controversial commit - a few typos I spotted while looking through the sourcecode. Furthermore, I noticed a couple of comments which seem to break off halfway through a sentence, but as I didn't know how they were meant to end, I didn't change them. Here they are (all under prettyplotlib/):

_pcolormesh.py:44 # If
_scatter.py:19 # [...] Can specify
_scatter.py:23 # [...] You can assign the
