### PR TITLE
Use Numpy's any to avoid error on None

### DIFF
--- a/prettyplotlib/_pcolormesh.py
+++ b/prettyplotlib/_pcolormesh.py
@@ -86,11 +86,11 @@ def pcolormesh(*args, **kwargs):
     # Get rid of ALL axes
     remove_chartjunk(ax, ['top', 'right', 'left', 'bottom'])
 
-    if any(xticklabels):
+    if np.any(xticklabels):
         xticks = np.arange(0.5, x.shape[1] + 0.5)
         ax.set_xticks(xticks)
         ax.set_xticklabels(xticklabels, rotation=xticklabels_rotation)
-    if any(yticklabels):
+    if np.any(yticklabels):
         yticks = np.arange(0.5, x.shape[0] + 0.5)
         ax.set_yticks(yticks)
         ax.set_yticklabels(yticklabels, rotation=yticklabels_rotation)


### PR DESCRIPTION
Using Python3.3, I got an error when doing

``` python
pcolormesh(C, norm=SymLogNorm(1.0))
```

It complained that _None_ was not iterable for:

``` python
if any(xticklabels):
    ...
```

I did not experience it on Python2.7, so perhaps they
changed the implementation of _any_. In any case, using
Numpy's _any_ function fixes the issue because it correctly
returns _False_ if the object is _None_.
