### PR TITLE
Fix issue #48 : X and Y vectors can now be passed as pcolormesh argument

### DIFF
--- a/prettyplotlib/_bar.py
+++ b/prettyplotlib/_bar.py
@@ -136,7 +136,11 @@ def bar(*args, **kwargs):
         ax.set_ylim(ymin, ymax)
         yrange = ymax - ymin
 
-        offset_ = yrange * annotate_yrange_factor
+        if kwargs.get('log') == True :
+            offset_ = np.log(yrange) * annotate_yrange_factor
+        else :
+            offset_= yrange * annotate_yrange_factor
+
         if isinstance(annotate, collections.Iterable):
             annotations = map(str, annotate)
         else:

--- a/prettyplotlib/_pcolormesh.py
+++ b/prettyplotlib/_pcolormesh.py
@@ -31,10 +31,18 @@ def pcolormesh(*args, **kwargs):
     #  out
     fig, ax, args, kwargs = maybe_get_fig_ax(*args, **kwargs)
 
-    x = args[0]
+    # If x and y axis are passed in arguments, gets correct data
+    # Ticks will work with x and y data, although it would be pointless to use
+    # both x/y and custom ticks
+    if len(args) == 3 :
+        x    = args[0]
+        y    = args[1]
+        data = args[2]
+    elif len(args) == 1 :
+        data = args[0]
 
-    kwargs.setdefault('vmax', x.max())
-    kwargs.setdefault('vmin', x.min())
+    kwargs.setdefault('vmax', data.max())
+    kwargs.setdefault('vmin', data.min())
 
     center_value = kwargs.pop('center_value', 0)
 
@@ -81,17 +89,32 @@ def pcolormesh(*args, **kwargs):
     orientation_colorbar = kwargs.pop('orientation_colorbar', 'vertical')
 
     p = ax.pcolormesh(*args, **kwargs)
-    ax.set_ylim(0, x.shape[0])
 
     # Get rid of ALL axes
     remove_chartjunk(ax, ['top', 'right', 'left', 'bottom'])
 
     if xticklabels is not None and any(xticklabels):
-        xticks = np.arange(0.5, x.shape[1] + 0.5)
+        if len(args) == 1:
+            xticks = np.arange(0.5, data.shape[1] + 0.5)
+        else:
+            xticks = []
+            for i in np.arange(len(x)-1):
+                half = float(x[i+1]-x[i])/2.+x[i]
+                print half
+                xticks.append(half)
+        xticks=np.array(xticks)
         ax.set_xticks(xticks)
         ax.set_xticklabels(xticklabels, rotation=xticklabels_rotation)
+
     if yticklabels is not None and any(yticklabels):
-        yticks = np.arange(0.5, x.shape[0] + 0.5)
+        if len(args) == 1:
+            yticks = np.arange(0.5, data.shape[1] + 0.5)
+        else:
+            yticks = []
+            for i in np.arange(len(y)-1):
+                half = float(y[i+1]-y[i])/2.+y[i]
+                yticks.append(half)
+        yticks=np.array(yticks)
         ax.set_yticks(yticks)
         ax.set_yticklabels(yticklabels, rotation=yticklabels_rotation)
 

--- a/tests/test_bar.py
+++ b/tests/test_bar.py
@@ -53,6 +53,15 @@ def test_bar_xticklabels():
     # fig.savefig('%s/baseline_images/test_bar/bar_xticklabels.png' %
     #             os.path.dirname(__file__))
 
+@image_comparison(baseline_images=['bar_log'], extensions=['png'])
+def test_bar_log():
+    np.random.seed(14)
+    x = np.arange(10)
+    y = np.exp(np.random.random(10)*5)
+    ppl.bar(x,y)
+    # fig.savefig('%s/baseline_images/test_bar/bar.png' %
+    #             os.path.dirname(__file__))
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=['-s', '--with-doctest'])

--- a/tests/test_pcolormesh.py
+++ b/tests/test_pcolormesh.py
@@ -94,6 +94,15 @@ def test_pcolormesh_lognorm():
     # fig.savefig('%s/baseline_images/test_pcolormesh/test_pcolormesh_lognorm.png' %
     #             os.path.dirname(__file__))
 
+@image_comparison(baseline_images=['pcolormesh_axes'], extensions=['png'])
+def test_pcolormesh_axes():
+    np.random.seed(10)
+    x=np.arange(0,100,10)
+    y=np.arange(0,20,2)
+
+    ppl.pcolormesh(x, y, np.random.randn(10, 10))
+    # fig.savefig('%s/baseline_images/test_pcolormesh/pcolormesh.png' %
+    #             os.path.dirname(__file__))
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
I patched the _pcolormesh file so that it your custom function can receive an X and Y axis (as in the original function). I also made it so that ticks with label get centered on the columns even if X/Y vectors are passed. 
