### PR TITLE
Set also xlim to the size of the input in pcolormesh

### DIFF
--- a/prettyplotlib/_pcolormesh.py
+++ b/prettyplotlib/_pcolormesh.py
@@ -82,6 +82,7 @@ def pcolormesh(*args, **kwargs):
 
     p = ax.pcolormesh(*args, **kwargs)
     ax.set_ylim(0, x.shape[0])
+    ax.set_xlim(0, x.shape[1])
 
     # Get rid of ALL axes
     remove_chartjunk(ax, ['top', 'right', 'left', 'bottom'])


### PR DESCRIPTION
I see you are only setting `ylim` and not `xlim`, is there a reason for that?

I did a few heatmaps and they had annoying right side white space due to that, so I suggest to change it.
