### PR TITLE
fixed example of the boxplot in the documentation

### DIFF
--- a/docs/examples_with_code.md
+++ b/docs/examples_with_code.md
@@ -448,7 +448,7 @@ If you have several things you'd like to compare distributions with, the `boxplo
 ```python
 import prettyplotlib as ppl
 import numpy as np
-import matplotlib as mpl
+import matplotlib.pyplot as plt
 
 np.random.seed(10)
 


### PR DESCRIPTION
Super tiny fix: The example on the boxplot (in the documetation) was broken because of a missing import
