### PR TITLE
Pass input args to ax.legend()

### DIFF
--- a/prettyplotlib/_legend.py
+++ b/prettyplotlib/_legend.py
@@ -21,7 +21,7 @@ def legend(*args, **kwargs):
     kwargs.setdefault('frameon', True)
     kwargs.setdefault('scatterpoints', True)
 
-    legend = ax.legend(**kwargs)
+    legend = ax.legend(*args, **kwargs)
     try:
         rect = legend.get_frame()
         rect.set_facecolor(facecolor)


### PR DESCRIPTION
Looks like the non-keyword arguments to prettyplotlib.legend() are currently ignored. This edit just passes those args on.
