### PR TITLE
Keep ppl.subplot{s,2grid}.__module__ correct.

### DIFF
--- a/prettyplotlib/general.py
+++ b/prettyplotlib/general.py
@@ -1,15 +1,16 @@
 import matplotlib.pyplot as plt
-from functools import wraps
+from functools import partial, update_wrapper
 
 from prettyplotlib.colors import pretty
 
 
-@wraps(plt.subplots)
+@partial(update_wrapper, wrapped=plt.subplots, assigned=["__doc__"])
 @pretty
 def subplots(*args, **kwargs):
     return plt.subplots(*args, **kwargs)
 
-@wraps(plt.subplot2grid)
+
+@partial(update_wrapper, wrapped=plt.subplot2grid, assigned=["__doc__"])
 @pretty
 def subplot2grid(*args, **kwargs):
     return plt.subplot2grid(*args, **kwargs)


### PR DESCRIPTION
functools.wraps optimistically sets the **module** attribute of these
functions to mpl.pyplot, but we only want to set **doc** and
**wrapped**, so that the functions appear in pydoc.

Fixes #65.
